### PR TITLE
Ensure imported PayPal Subscriptions map correctly

### DIFF
--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -400,7 +400,7 @@ class WCS_Admin_Importer {
 									<option value="shipping_method" <?php selected( $header, 'shipping_method' ); ?>>shipping_method</option>
 									<option value="shipping_method_title" <?php selected( $header, 'shipping_method_title' ); ?>>shipping_method_title</option>
 									<option value="_stripe_customer_id" <?php selected( $header, 'stripe_customer_id' ); ?>>stripe_customer_id</option>
-									<option value="PayPal Subscriber ID" <?php selected( $header, 'PayPal Subscriber ID' ); ?>>PayPal Subscriber id</option>
+									<option value="_paypal_subscriber_id" <?php selected( $header, 'paypal_subscriber_id' ); ?>>paypal_subscriber_id</option>
 									<option value="_wc_authorize_net_cim_payment_profile_id" <?php selected( $header, 'wc_authorize_net_cim_payment_profile_id' ); ?>>wc_authorize_net_cim_payment_profile_id</option>
 									<option value="_wc_authorize_net_cim_customer_profile_id" <?php selected( $header, 'wc_authorize_net_cim_customer_profile_id' ); ?>>wc_authorize_net_cim_customer_profile_id</option>
 									<option value="download_permission_granted" <?php selected( $header, 'download_permission_granted' ); ?>>download_permission_granted</option>
@@ -558,7 +558,7 @@ class WCS_Admin_Importer {
 			'order_total' 						 		=> '',
 			'order_recurring_total'				 		=> '',
 			'_stripe_customer_id'				  		=> '',
-			'PayPal Subscriber ID'				  		=> '',
+			'_paypal_subscriber_id'				  		=> '',
 			'payment_method_title'						=> '',
 			'_wc_authorize_net_cim_payment_profile_id' 	=> '',
 			'_wc_authorize_net_cim_customer_profile_id' => '',

--- a/includes/class-wcs-import-parser.php
+++ b/includes/class-wcs-import-parser.php
@@ -79,7 +79,7 @@ class WCS_Import_Parser {
 	);
 
 	static $supported_payment_gateways = array (
-		'paypal'            => array( 'PayPal Subscriber ID' ),
+		'paypal'            => array( '_paypal_subscriber_id' ),
 		'stripe'            => array( '_stripe_customer_id' ),
 		'authorize_net_cim'     => array( '_wc_authorize_net_cim_customer_profile_id', '_wc_authorize_net_cim_payment_profile_id' ),
 	);


### PR DESCRIPTION
Hey @mattallan and @thenbrent,

I've just been working on a Cart66 Subscriptions to WooCommerce Subscriptions plugin and I noticed during my testing that when you do an import currently the `paypal_subscriber_id` doesn't get mapped correctly.

Currently the plugin does the following:
![option](https://cloud.githubusercontent.com/assets/1377956/4804047/9b961462-5e63-11e4-9914-59709985f862.png)
![do-not-import](https://cloud.githubusercontent.com/assets/1377956/4804048/9e9be9e8-5e63-11e4-8ebf-ee7cf8366876.png)

This PR fixes those issues.

Great work on the plugin too gents :+1: 
