### PR TITLE
Remove meta causing adding download permissions to be skipped

### DIFF
--- a/includes/class-wcs-import-parser.php
+++ b/includes/class-wcs-import-parser.php
@@ -438,6 +438,7 @@ class WCS_Import_Parser {
 
 				// add download permissions if specified
 				if( $download_permissions_granted ) {
+					delete_post_meta( $order_id, '_download_permissions_granted' );
 					wc_downloadable_product_permissions( $order_id );
 				}
 


### PR DESCRIPTION
Quick patch to make sure that `_download_permissions_granted` is removed so that the correct download permissions are set on the imported subscriptions.

For #86.
