### PR TITLE
Fix documentation button link

### DIFF
--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -168,7 +168,7 @@ class WCS_Import_Admin {
 				<div class="squeezer">
 					<h4><?php printf( esc_html__( '%sBefore you begin%s, please prepare your CSV file.', 'wcs-import-export' ), '<strong>', '</strong>' ); ?></h4>
 					<p class="submit">
-						<a href="http://docs.woothemes.com/document/subscriptions-importer/" class="button-primary"><?php esc_html_e( 'Documentation', 'wcs-import-export' ); ?></a>
+						<a href="https://github.com/prospress/woocommerce-subscriptions-importer/blob/master/README.md" class="button-primary"><?php esc_html_e( 'Documentation', 'wcs-import-export' ); ?></a>
 						<a href="<?php echo esc_url( WCS_Importer_Exporter::plugin_url() . 'wcs-import-sample.csv' ); ?>" class="button wcs-importer-download"><?php esc_html_e( 'Download Example CSV', 'wcs-import-export' ); ?></a>
 					</p>
 				</div>


### PR DESCRIPTION
We'll probably want to change this again to something else after we publish docs elsewhere, but for now, the README will do.
