### PR TITLE
Tweak support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Import subscriptions to WooCommerce via CSV, or export your subscriptions from W
 
 ---
 
+# Support
+
+The WooCommerce Subscriptions Import and Export tool is released freely and openly to help WooCommerce developers migrate subscriber data to [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/). Even with this plugin, migrations involve a lot of manual work to format subscription data correctly and test imports. Neither [Prospress](https://prospress.com/) nor [WooCommerce](http://woocommerce.com/) provide services to complete a migration with this tool.
+
+For help with a migration, please contact [WisdmLabs](https://wisdmlabs.com/), an official partner for this extension.
+
+You can learn more about the migration service WisdmLabs offer and contact them via their [WooCommerce Subscriptions Migration page](https://wisdmlabs.com/woocommerce-subscriptions-migration-partner/).
+
+Prospress do not provide support for migration issues. This means Prospress can not help with CSV formatting, fixing broken renewals or other issues with subscriptions imported incorrectly. Similarly, issues with subscriptions created with this plugin are not supported via the WooCommerce support system.
+
+If you think you have found a bug in the extension, problem with the documentation or limitation in the data the can be imported, please [open a new issue to report it](https://github.com/Prospress/woocommerce-subscriptions-import-export/issues/new).
+
+---
+
 # Subscriptions Importer
 With the WooCommerce Subscriptions CSV Importer, you can import subscriptions from a CSV file into your WooCommerce store. This is particularly useful when migrating stores from a different eCommerce platform.
 
@@ -572,13 +586,3 @@ Before exporting, you have the option to modify the column names which are writt
 `tax_items`               |`string`|Taxes|
 `download_permissions`    |`int`|Download permissions granted (1 or 0)|
 
----
-
-# Support
-
-Please note, due to the complexity of the import process, we (Prospress) can not provide support for your import, including issues with CSV formatting or help after an import which did not set data correctly. Furthermore, issues with subscriptions created via the CSV importer may not be supported via the [WooThemes](http://woothemes.com/) support system for the WooCommerce Subscriptions extension.
-
-If you're looking to get help with your migrations, please get in contact with one of our migration partners:
- - [WisdmLabs](https://wisdmlabs.com/woocommerce-subscriptions-migration-partner/) - "We offer end-to-end technology solutions to help niche-to-enterprise Ecommerce brands grow and evolve. Our experience with open source software and WooCommerce provides businesses with sustainable growth today, and also a firm foundation to scale tomorrow. At the core of all this lies our highly professional process backed technology team, business strategy function and very human centric support vertical."
-
-If you think you have found a bug, problem with the documentation or limitation in the data the can be imported, please [open a new issue to report it](https://github.com/Prospress/woocommerce-subscriptions-import-export/issues/new).


### PR DESCRIPTION
- move to the top so it's front of mind
- add link to prospress.com
- rename WooThemes with WooCommerce and change URL
- be more direct with language around not providing support and
  contacting WisdmLabs so that its explicit
- don't use a list for migration partners when we only have one
- remove marketing copy from WisdmLabs that doesn't relate to
  the migration service
