### PR TITLE
Tweak test install script output

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -21,7 +21,7 @@ set -ex
 install_wp() {
 
 	# make wordpress dirtectory
-	mkdir -p $WP_CORE_DIR
+	mkdir -p "$WP_CORE_DIR"
 
 	# corect WP archive to grab
 	if [ $WP_VERSION == 'latest' ]; then
@@ -34,10 +34,10 @@ install_wp() {
 	curl https://wordpress.org/${ARCHIVE_NAME}.tar.gz --output /tmp/wordpress.tar.gz --silent
 
 	# unconpress it
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C "$WP_CORE_DIR"
 
 	# get a test db config
-	curl https://raw.github.com/markoheijnen/wp-mysqli/master/db.php?access_token=$GITHUB_TOKEN --output $WP_CORE_DIR/wp-content/db.php --silent
+	curl https://raw.github.com/markoheijnen/wp-mysqli/master/db.php?access_token=$GITHUB_TOKEN --output "$WP_CORE_DIR/wp-content/db.php" --silent
 
 }
 
@@ -51,8 +51,8 @@ install_test_suite() {
 	fi
 
 	# set up testing suite in wordpress test libary directory
-	mkdir -p $WP_TESTS_DIR
-	cd $WP_TESTS_DIR
+	mkdir -p "$WP_TESTS_DIR"
+	cd "$WP_TESTS_DIR"
 	svn co --quiet http://develop.svn.wordpress.org/tags/4.3.1/tests/phpunit/includes/
 
 	curl http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php --output wp-tests-config.php --silent

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -79,19 +79,19 @@ install_cs() {
 	mkdir -p "php-codesniffer"
 
 	# uncompress codesniffer into the directory we created
-	curl -L https://api.github.com/repos/squizlabs/PHP_CodeSniffer/tarball/2.3.3?access_token=$GITHUB_TOKEN | tar --strip-components=1 -zx -C "php-codesniffer"
+	curl -L https://api.github.com/repos/squizlabs/PHP_CodeSniffer/tarball/2.3.3?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "php-codesniffer"
 
 	# make a directory for the WP coding standard rules
 	mkdir -p "wordpress-coding-standards"
 
 	# uncompress the coding standards into the directory we created
-	curl -L https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/tarball/0.6.0?access_token=$GITHUB_TOKEN | tar --strip-components=1 -zx -C "wordpress-coding-standards"
+	curl -L https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/tarball/0.6.0?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "wordpress-coding-standards"
 
 	# make a directory for the Prospress coding standard rules
 	mkdir -p "prospress-coding-standards"
 
 	# uncompress the coding standards into the directory we created
-	curl -L https://api.github.com/repos/Prospress/prospress-coding-standards/tarball/master?access_token=$GITHUB_TOKEN | tar --strip-components=1 -zx -C "prospress-coding-standards"
+	curl -L https://api.github.com/repos/Prospress/prospress-coding-standards/tarball/master?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "prospress-coding-standards"
 
 	# move in the codesniffer directory
 	cd php-codesniffer

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -16,7 +16,11 @@ WP_VERSION=${5-latest}
 WP_TESTS_DIR="${PWD}/tmp/wordpress-tests-lib"
 WP_CORE_DIR="${PWD}/tmp/wordpress/"
 
-set -ex
+set -e
+
+say() {
+  echo -e "$1"
+}
 
 install_wp() {
 
@@ -38,6 +42,8 @@ install_wp() {
 
 	# get a test db config
 	curl https://raw.github.com/markoheijnen/wp-mysqli/master/db.php?access_token=$GITHUB_TOKEN --output "$WP_CORE_DIR/wp-content/db.php" --silent
+
+	say "WordPress Installed"
 
 }
 
@@ -68,6 +74,8 @@ install_test_suite() {
 	sed $ioption "s/admin@example.org/tests@woocommerce.com/" wp-tests-config.php
 	sed $ioption "s/Test Blog/WooCommerce Unit Tests/" wp-tests-config.php
 
+	say "Test Suite Installed"
+
 }
 
 install_cs() {
@@ -80,6 +88,8 @@ install_cs() {
 
 	# uncompress codesniffer into the directory we created
 	curl -L https://api.github.com/repos/squizlabs/PHP_CodeSniffer/tarball/2.3.3?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "php-codesniffer"
+
+	say "PHP_CodeSniffer Installed"
 
 	# make a directory for the WP coding standard rules
 	mkdir -p "wordpress-coding-standards"
@@ -96,8 +106,10 @@ install_cs() {
 	# move in the codesniffer directory
 	cd php-codesniffer
 
- 	# install the WP conding standard rules
+ 	# install the WP coding standard rules
  	scripts/phpcs --config-set installed_paths ../wordpress-coding-standards,../prospress-coding-standards
+
+	say "Coding Standards Installed"
 
  	# for consistency move back into the tmp directory
  	cd ../
@@ -125,6 +137,8 @@ install_db() {
 	# create database - more generic than MAMP for use on multple system
 	#/Applications/MAMP/Library/bin/mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+
+	say "Database Created"
 
 }
 

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -5,7 +5,7 @@ if [ $1 == 'before' ]; then
 
 	# place a copy of woocommerce where the unit tests etc. expect it to be
 	mkdir -p "../woocommerce"
-	curl -L https://api.github.com/repos/woothemes/woocommerce/tarball/$WC_VERSION?access_token=$GITHUB_TOKEN | tar --strip-components=1 -zx -C "../woocommerce"
+	curl -L https://api.github.com/repos/woothemes/woocommerce/tarball/$WC_VERSION?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "../woocommerce"
 
 	# place a copy of woocommerce subscriptions where the unit tests etc. expect it to be - needs to be a repo with the test dir
 	git clone https://$GITHUB_TOKEN@github.com/Prospress/woocommerce-subscriptions.git "../woocommerce-subscriptions" -b $WCS_VERSION

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
 # usage: travis.sh before|after
 
+set -e
+
+say() {
+  echo -e "$1"
+}
+
 if [ $1 == 'before' ]; then
 
 	# place a copy of woocommerce where the unit tests etc. expect it to be
 	mkdir -p "../woocommerce"
 	curl -L https://api.github.com/repos/woothemes/woocommerce/tarball/$WC_VERSION?access_token=$GITHUB_TOKEN --silent | tar --strip-components=1 -zx -C "../woocommerce"
 
+	say "WooCommerce Installed"
+
 	# place a copy of woocommerce subscriptions where the unit tests etc. expect it to be - needs to be a repo with the test dir
 	git clone https://$GITHUB_TOKEN@github.com/Prospress/woocommerce-subscriptions.git "../woocommerce-subscriptions" -b $WCS_VERSION
+
+	say "WooCommerce Subscriptions Installed"
 
 fi


### PR DESCRIPTION
* 230b51f wraps `$WP_CORE_DIR` in quotes so it works with directory structures that may include spaces or other special chars
* 1f7da0f just sets our curls to be silent
* c2ae46c tweaks the output so that only what we want to show + errors is displayed rather than repeating commands etc.
* 80a604a implements changes as per https://github.com/Prospress/woocommerce-subscriptions/issues/801 for wcs