### PR TITLE
Add license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Prospress/woocommerce-subscriptions-importer-exporter.svg?branch=master)](https://travis-ci.org/Prospress/woocommerce-subscriptions-importer-exporter)
 [![codecov](https://codecov.io/gh/Prospress/woocommerce-subscriptions-importer-exporter/branch/master/graph/badge.svg)](https://codecov.io/gh/Prospress/woocommerce-subscriptions-importer-exporter)
+[![license: GPL v2](https://img.shields.io/badge/license-GPLv2-blue.svg)](http://opensource.org/licenses/GPL-2.0)
 
 Import subscriptions to WooCommerce via CSV, or export your subscriptions from WooCommerce to a CSV.
 


### PR DESCRIPTION
Tiny edit to the README file to add a GPLv2 license badge.

Uses [shields.io](http://shields.io/). Lots of services include Travis etc. that use the [same standard](https://github.com/badges/shields#services-using-the-shields-standard)

Why?

* Noticed this sort of thing being used on quite a few repos I've looked at lately - I quite like the idea
* Easy for people to find
* Licensing is important
* We could be using a different [GPL compatible](https://en.wikipedia.org/wiki/License_compatibility#GPL_compatibility) license - this helps clarify when looking at the repo

(We've got GPLv2 here https://github.com/Prospress/woocommerce-subscriptions-importer-exporter/blob/master/wcs-importer-exporter.php#L9 so just running with that unless we do want to go v3 or something else - in which case lets discuss)