### PR TITLE
Coding standard fixes

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -60,7 +60,7 @@ class WCS_Export_Admin {
 
 		<?php if ( ! empty( $this->error_message ) ) : ?>
 			<div id="message" class="error">
-				<p><?php esc_html_e( $this->error_message, 'wcs-import-export' ); ?></p>
+				<p><?php echo esc_html( $this->error_message ); ?></p>
 			</div>
 		<?php endif; ?>
 
@@ -135,7 +135,7 @@ class WCS_Export_Admin {
 								<option value="none"><?php esc_html_e( 'None', 'wcs-import-export' ); ?></option>
 
 								<?php foreach ( WC()->payment_gateways->get_available_payment_gateways() as $gateway_id => $gateway ) : ?>
-									<option value="<?php echo esc_attr( $gateway_id ); ?>"><?php esc_html_e( $gateway->title, 'wcs-import-export' ); ?></option>;
+									<option value="<?php echo esc_attr( $gateway_id ); ?>"><?php echo esc_html( $gateway->title ); ?></option>;
 								<?php endforeach; ?>
 							</select>
 						</td>
@@ -237,7 +237,7 @@ class WCS_Export_Admin {
 				<?php foreach ( $csv_headers as $data => $title ) : ?>
 					<tr>
 						<td width="15" style="text-align:center"><input type="checkbox" name="mapped[<?php echo esc_attr( $data ); ?>]" checked></td>
-						<td><label><?php esc_html_e( $title, 'wcs-import-export' ); ?></label></td>
+						<td><label><?php echo esc_html( $title ); ?></label></td>
 						<td><label><?php echo esc_html( $data ); ?></label></td>
 						<td><input type="text" name="<?php echo esc_attr( $data ); ?>" value="<?php echo esc_attr( $data ); ?>" placeholder="<?php echo esc_attr( $data ); ?>"></td>
 					</tr>

--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -34,7 +34,7 @@ class WCS_Exporter {
 		$fee_total = $fee_tax_total = 0;
 		$fee_items = array();
 
-		if ( 0 != sizeof( array_intersect( array_keys( self::$headers ), array( 'fee_total', 'fee_tax_total', 'fee_items' ) ) ) ) {
+		if ( 0 != count( array_intersect( array_keys( self::$headers ), array( 'fee_total', 'fee_tax_total', 'fee_items' ) ) ) ) {
 			foreach ( $subscription->get_fees() as $fee_id => $fee ) {
 
 				$fee_items[] = implode( '|', array(

--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -270,8 +270,8 @@ class WCS_Exporter {
 
 					foreach ( $subscription->get_tax_totals() as $tax_code => $tax ) {
 						$tax_items[] = implode( '|', array(
-							'id:' .    $tax->rate_id,
-							'code:' .  $tax->label,
+							'id:' . $tax->rate_id,
+							'code:' . $tax->label,
 							'total:' . wc_format_decimal( $tax->amount, 2 ),
 						) );
 					}

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -120,7 +120,7 @@ class WCS_Import_Admin {
 				$script_data = array(
 					'success' 				=> esc_html__( 'success', 'wcs-import-export' ),
 					'failed' 				=> esc_html__( 'failed', 'wcs-import-export' ),
-					'error_string'			=> esc_html( sprintf( __( 'Row #%s from CSV %sfailed to import%s with error/s: %s', 'wcs-import-export' ), '{row_number}', '<strong>', '</strong>', '{error_messages}' ) ),
+					'error_string'			=> esc_html( sprintf( __( 'Row #%1$s from CSV %2$sfailed to import%3$s with error/s: %4$s', 'wcs-import-export' ), '{row_number}', '<strong>', '</strong>', '{error_messages}' ) ),
 					'finished_importing' 	=> esc_html__( 'Finished Importing', 'wcs-import-export' ),
 					'edit_order' 			=> esc_html__( 'Edit Order', 'wcs-import-export' ),
 					'warning'				=> esc_html__( 'Warning', 'wcs-import-export' ),
@@ -167,7 +167,7 @@ class WCS_Import_Admin {
 			<?php endif; ?>
 			<?php if ( ! isset( $_GET['step'] ) ) : ?>
 				<div class="squeezer">
-					<h4><?php printf( esc_html__( '%sBefore you begin%s, please prepare your CSV file.', 'wcs-import-export' ), '<strong>', '</strong>' ); ?></h4>
+					<h4><?php printf( esc_html__( '%1$sBefore you begin%2$s, please prepare your CSV file.', 'wcs-import-export' ), '<strong>', '</strong>' ); ?></h4>
 					<p class="submit">
 						<a href="https://github.com/prospress/woocommerce-subscriptions-import-export/blob/master/README.md" class="button-primary"><?php esc_html_e( 'Documentation', 'wcs-import-export' ); ?></a>
 						<a href="<?php echo esc_url( WCS_Importer_Exporter::plugin_url() . 'wcs-import-sample.csv' ); ?>" class="button wcs-importer-download"><?php esc_html_e( 'Download Example CSV', 'wcs-import-export' ); ?></a>
@@ -263,7 +263,7 @@ class WCS_Import_Admin {
 								<th><?php esc_html_e( 'Add Memberships:', 'wcs-import-export' ); ?></th>
 								<td>
 									<input type="checkbox" name="add_memberships" value="yes" <?php checked( $add_memberships, 'yes' ); ?> />
-									<em><?php printf( esc_html__( 'Automatically add the membership to the new subscription if it contains a product that is part of a membership plan (only works with %sWooCommerce Memberships%s).', 'wcs-import-export' ), '<a href="https://www.woothemes.com/products/woocommerce-memberships/">', '</a>' ); ?></em>
+									<em><?php printf( esc_html__( 'Automatically add the membership to the new subscription if it contains a product that is part of a membership plan (only works with %1$sWooCommerce Memberships%2$s).', 'wcs-import-export' ), '<a href="https://www.woothemes.com/products/woocommerce-memberships/">', '</a>' ); ?></em>
 								</td>
 							</tr>
 						<?php endif; ?>

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -876,5 +876,3 @@ class WCS_Importer {
 		return $chosen_tax_rate_id;
 	}
 }
-
-?>

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -525,11 +525,11 @@ class WCS_Importer {
 				if ( $meta_set ) {
 					$subscription->set_payment_method( $payment_gateway, $payment_method_data );
 				} else {
-					$warnings[] = sprintf( esc_html__( 'No payment meta was set for your %s subscription (%s). The next renewal is going to fail if you leave this.', 'wcs-import-export' ), $payment_method, $subscription->id );
+					$warnings[] = sprintf( esc_html__( 'No payment meta was set for your %1$s subscription (%2$s). The next renewal is going to fail if you leave this.', 'wcs-import-export' ), $payment_method, $subscription->id );
 				}
 			} else {
 				if ( 'paypal' == $payment_method ) {
-					$warnings[] = sprintf( esc_html__( 'Could not set payment method as PayPal, defaulted to manual renewals. Either PayPal was not enabled or your PayPal account does not have Reference Transaction setup. Learn more about enabling Reference Transactions %shere%s.', 'wcs-import-export' ), '<a href="https://support.woothemes.com/hc/en-us/articles/205151193-PayPal-Reference-Transactions-for-Subscriptions">', '</a>' );
+					$warnings[] = sprintf( esc_html__( 'Could not set payment method as PayPal, defaulted to manual renewals. Either PayPal was not enabled or your PayPal account does not have Reference Transaction setup. Learn more about enabling Reference Transactions %1$shere%2$s.', 'wcs-import-export' ), '<a href="https://support.woothemes.com/hc/en-us/articles/205151193-PayPal-Reference-Transactions-for-Subscriptions">', '</a>' );
 				} else {
 					$warnings[] = sprintf( esc_html__( 'The payment method "%s" is either not enabled or does not support the new features of Subscriptions 2.0 and can not be properly attached to your subscription. This subscription has been set to manual renewals.', 'wcs-import-export' ), $payment_method );
 				}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -395,11 +395,11 @@ class WCS_Importer {
 				// only show the following warnings on the import when the subscription requires shipping
 				if ( ! self::$all_virtual ) {
 					if ( ! empty( $missing_shipping_addresses ) ) {
-						$result['warning'][] = esc_html__( 'The following shipping address fields have been left empty: ' . rtrim( implode( ', ', $missing_shipping_addresses ), ',' ) . '. ', 'wcs-import-export' );
+						$result['warning'][] = sprintf( esc_html__( 'The following shipping address fields have been left empty: %s. ', 'wcs-import-export' ), rtrim( implode( ', ', $missing_shipping_addresses ), ',' ) );
 					}
 
 					if ( ! empty( $missing_billing_addresses ) ) {
-						$result['warning'][] = esc_html__( 'The following billing address fields have been left empty: ' . rtrim( implode( ', ', $missing_billing_addresses ), ',' ) . '. ', 'wcs-import-export' );
+						$result['warning'][] = sprintf( esc_html__( 'The following billing address fields have been left empty: %s. ', 'wcs-import-export' ), rtrim( implode( ', ', $missing_billing_addresses ), ',' ) );
 					}
 
 					if ( empty( $shipping_method ) ) {
@@ -853,7 +853,7 @@ class WCS_Importer {
 				} elseif ( ! empty( $tax_data['code'] ) ) {
 					$tax_rate = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_name = %s ORDER BY tax_rate_priority LIMIT 1", $tax_data['code'] ) );
 				} else {
-					$result['warning'][] = esc_html__( sprintf( 'Missing tax code or ID from column: %s', self::$fields['tax_items'] ), 'wcs-import-export' );
+					$result['warning'][] = sprintf( esc_html__( 'Missing tax code or ID from column: %s', 'wcs-import-export' ), self::$fields['tax_items'] );
 				}
 
 				if ( ! empty( $tax_rate ) ) {
@@ -868,7 +868,7 @@ class WCS_Importer {
 						}
 					}
 				} else {
-					$result['warning'][] = esc_html__( sprintf( 'The tax code "%s" could not be found in your store.', $tax_data['code'] ), 'wcs-import-export' );
+					$result['warning'][] = sprintf( esc_html__( 'The tax code "%s" could not be found in your store.', 'wcs-import-export' ), $tax_data['code'] );
 				}
 			}
 		}

--- a/templates/import-results.php
+++ b/templates/import-results.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <h3><?php esc_html_e( 'Importing Results', 'wcs-import-export' ); ?></h3>
 
 <p id="wcsi-timeout" style="display: none;">
-	<?php echo wp_kses( sprintf( __( 'Error: The importing process has timed out. Please check the CSV is correct and do a test run before importing by enabling the checkbox on the Importer Home screen. %s Start Over. %s', 'wcs-import-export' ), '<a href="' . $this->admin_url . '">', '</a>' ), array( 'a' => array( 'href' => true ) ) ); ?>
+	<?php echo wp_kses( sprintf( __( 'Error: The importing process has timed out. Please check the CSV is correct and do a test run before importing by enabling the checkbox on the Importer Home screen. %1$s Start Over. %2$s', 'wcs-import-export' ), '<a href="' . $this->admin_url . '">', '</a>' ), array( 'a' => array( 'href' => true ) ) ); ?>
 </p>
 <p id="wcsi-time-completion">
 	<?php echo wp_kses( sprintf( __( 'Total Estimated Import Time Between: %1$s 0%2$s minutes. ( %3$s0%4$s Completed! )', 'wcs-import-export' ), '<span id="wcsi-estimated-time">', '</span>', '<span id="wcsi-completed-percent">', '</span>' ), array( 'span' => array( 'id' => true ) ) ); ?>

--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -90,16 +90,16 @@ class WCS_Importer_Exporter {
 		if ( ! class_exists( 'WC_Subscriptions' ) || ! class_exists( 'WC_Subscriptions_Admin' ) ) :
 			if ( is_woocommerce_active() ) : ?>
 				<div id="message" class="error">
-					<p><?php printf( esc_html__( '%sWooCommerce Subscriptions Importer is inactive.%s The %sWooCommerce Subscriptions plugin%s must be active for WooCommerce Subscriptions Importer to work. Please %sinstall & activate%s WooCommerce.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s The %3$sWooCommerce Subscriptions plugin%4$s must be active for WooCommerce Subscriptions Importer to work. Please %5$sinstall & activate%6$s WooCommerce.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 				</div>
 			<?php else : ?>
 				<div id="message" class="error">
-					<p><?php printf( esc_html__( '%sWooCommerce Subscriptions Importer is inactive. %sBoth %sWooCommerce%s and %sWooCommerce Subscriptions%s plugins must be active for WooCommerce Subscriptions Importer to work. Please %sinstall & activate%s these plugins before continuing.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://wordpress.org/extend/plugins/woocommerce/">', '</a>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+					<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s Both %3$sWooCommerce%4$s and %5$sWooCommerce Subscriptions%6$s plugins must be active for WooCommerce Subscriptions Importer to work. Please %7$sinstall & activate%8$s these plugins before continuing.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://wordpress.org/extend/plugins/woocommerce/">', '</a>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 				</div>
 			<?php endif;?>
 		<?php elseif ( ! class_exists( 'WC_Subscriptions' ) || version_compare( WC_Subscriptions::$version, '2.0', '<' ) ) : ?>
 			<div id="message" class="error">
-				<p><?php printf( esc_html__( '%sWooCommerce Subscriptions Importer is inactive.%s The %sWooCommerce Subscriptions%s version 2.0 (or greater) is required to safely run WooCommerce Subscriptions Importer. Please %supdate & activate%s WooCommerce Subscriptions.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '&nbsp;&raquo;</a>' ); ?></p>
+				<p><?php printf( esc_html__( '%1$sWooCommerce Subscriptions Importer is inactive.%2$s The %3$sWooCommerce Subscriptions%4$s version 2.0 (or greater) is required to safely run WooCommerce Subscriptions Importer. Please %5$supdate & activate%6$s WooCommerce Subscriptions.', 'wcs-import-export' ), '<strong>', '</strong>', '<a href="http://www.woothemes.com/products/woocommerce-subscriptions/">', '</a>', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '&nbsp;&raquo;</a>' ); ?></p>
 			</div>
 		<?php endif;
 	}


### PR DESCRIPTION
Getting in some coding standard fixes to avoid 🔴 before I implement https://github.com/Prospress/prospress-coding-standards/issues/3

Please review carefully to make sure these aren't going to break anything.

Some additional background info on the commits:

* 933b331 the WordPress.WP.I18n sniff is now part of the WordPress Core rule set. When there is more than 1 placeholder in a translatable string they should be numbered - for RTL languages etc. it means the order can be moved around.
* d45701e some best practice concatenation tweaks (`WordPress.Extra` ruleset)
* 578f9ba best practice to not use `sizeof()` - main reason is that in php is simply an alias of `count()` (ref: http://php.net/manual/en/function.sizeof.php). In other languages `sizeof()` doesn't mean the same thing as it does in php so to prevent misinterpretation it is best to use `count()`.
* aca6258 don't need to the closing tag - general best practice e.g. http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag
* 9fdf259 fixes a few instances where we were translating variables that we didn't need to be plus changes a bunch of the translatable strings to make better use of placeholders rather than a concatenated string + variables approach (which don't translate nicely).
