### PR TITLE
Enable manual renewal option to be export and imported

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -193,6 +193,7 @@ class WCS_Export_Admin {
 			'payment_method_title'     => __( 'Payment Method Title', 'wcs-import-export' ),
 			'payment_method_post_meta' => __( 'Payment Method Post Meta', 'wcs-import-export' ),
 			'payment_method_user_meta' => __( 'Payment Method User Meta', 'wcs-import-export' ),
+			'requires_manual_renewal'  => __( 'Payment Method Manual Flag', 'wcs-import-export'),
 			'shipping_method'          => __( 'Shipping Method', 'wcs-import-export' ),
 			'billing_first_name'       => __( 'Billing First Name', 'wcs-import-export' ),
 			'billing_last_name'        => __( 'Billing Last Name', 'wcs-import-export' ),

--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -193,7 +193,7 @@ class WCS_Export_Admin {
 			'payment_method_title'     => __( 'Payment Method Title', 'wcs-import-export' ),
 			'payment_method_post_meta' => __( 'Payment Method Post Meta', 'wcs-import-export' ),
 			'payment_method_user_meta' => __( 'Payment Method User Meta', 'wcs-import-export' ),
-			'requires_manual_renewal'  => __( 'Payment Method Manual Flag', 'wcs-import-export'),
+			'requires_manual_renewal'  => __( 'Requires Manual Renewal Flag', 'wcs-import-export' ),
 			'shipping_method'          => __( 'Shipping Method', 'wcs-import-export' ),
 			'billing_first_name'       => __( 'Billing First Name', 'wcs-import-export' ),
 			'billing_last_name'        => __( 'Billing Last Name', 'wcs-import-export' ),

--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -107,6 +107,7 @@ class WCS_Exporter {
 				case 'end_date':
 				case 'payment_method':
 				case 'payment_method_title':
+				case 'requires_manual_renewal':
 				case 'billing_first_name':
 				case 'billing_last_name':
 				case 'billing_email':

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -385,6 +385,7 @@ class WCS_Import_Admin {
 									<option value="payment_method_title" <?php selected( $header, 'payment_method_title' ); ?>>payment_method_title</option>
 									<option value="payment_method_post_meta" <?php selected( $header, 'payment_method_post_meta' ); ?>>payment_method_post_meta</option>
 									<option value="payment_method_user_meta" <?php selected( $header, 'payment_method_user_meta' ); ?>>payment_method_user_meta</option>
+									<option value="requires_manual_renewal" <?php selected( $header, 'requires_manual_renewal' ); ?>>requires_manual_renewal</option>
 								</optgroup>
 								<optgroup label="<?php esc_attr_e( 'Address Details', 'wcs-import-export' ); ?>">
 									<?php foreach ( WCS_Importer::$user_meta_fields as $option ) : ?>
@@ -496,6 +497,7 @@ class WCS_Import_Admin {
 			'download_permissions'     => '',
 			'payment_method'           => '',
 			'payment_method_title'     => '',
+			'requires_manual_renewal'  => '',
 			'billing_period'           => '',
 			'billing_interval'         => '',
 		);

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -349,7 +349,7 @@ class WCS_Importer {
 					$subscription = null;
 				}
 
-				if ( $set_manual && ! $requires_manual_renewal ) {
+				if ( $set_manual ) {
 					$result['warning'][] = esc_html__( 'No payment method was given in CSV and so the subscription has been set to manual renewal.', 'wcs-import-export' );
 				} else if ( $requires_manual_renewal ) {
                     $result['warning'][] = esc_html__( 'Import forced manual renewal.', 'wcs-import-export' );

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -352,8 +352,8 @@ class WCS_Importer {
 				if ( $set_manual ) {
 					$result['warning'][] = esc_html__( 'No payment method was given in CSV and so the subscription has been set to manual renewal.', 'wcs-import-export' );
 				} else if ( $requires_manual_renewal ) {
-                    $result['warning'][] = esc_html__( 'Import forced manual renewal.', 'wcs-import-export' );
-                }
+					$result['warning'][] = esc_html__( 'Import forced manual renewal.', 'wcs-import-export' );
+				}
 
 				if ( ! empty( $data[ self::$fields['coupon_items'] ] ) ) {
 					self::add_coupons( $subscription, $data );

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -197,10 +197,6 @@ class WCS_Importer {
 					} else {
 						$set_manual = true;
 					}
-
-					if (!$set_manual && 'true' == $manual_flag ) {
-						$post_meta[] = array( 'key' => '_requires_manual_renewal', 'value' => 'true' );
-					}
 					break;
 
 				case 'shipping_address_1':
@@ -334,6 +330,10 @@ class WCS_Importer {
 						$subscription->update_manual();
 					} elseif ( ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) ) { // don't bother trying to set payment meta on a subscription that won't ever renew
 						$result['warning'] = array_merge( $result['warning'], self::set_payment_meta( $subscription, $data ) );
+					}
+
+					if ( 'true' == $manual_flag ) {
+						$subscription->update_manual();
 					}
 
 					if ( ! empty( $data[ self::$fields['order_notes'] ] ) ) {

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -199,7 +199,6 @@ class WCS_Importer {
 					}
 
 					if (!$set_manual && 'true' == $manual_flag ) {
-                        error_log('set manual flag');
 						$post_meta[] = array( 'key' => '_requires_manual_renewal', 'value' => 'true' );
 					}
 					break;


### PR DESCRIPTION
From discussions on #143

Add another field to the csv file exporter to store the boolean
flag that may be set for the subscription.
Add in the ability to read the csv on import to set the manual
flag as well as the payment method that was used.

e.g. The customer can say they paid by paypal standard and the
manual flag will be copied in so that the subscription is still
in a valid state for that payment method.