### PR TITLE
Calculate last_payment for imported subscriptions

### DIFF
--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -54,10 +54,9 @@ class WCS_Importer_Exporter {
 			add_filter('woocommerce_subscription_get_' . 'last_payment' . '_date', array(WCS_Importer_Exporter::class, 'last_payment_calculation'), 10, 3);
 		}
 		if ( is_admin() ) {
-			if (class_exists('WC_Subscriptions') && version_compare(WC_Subscriptions::$version, '2.0', '>=')) {
+			if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.0', '>=' ) ) {
 				self::$wcs_exporter = new WCS_Export_Admin();
 				self::$wcs_importer = new WCS_Import_Admin();
-
 			} else {
 				add_action( 'admin_notices', __CLASS__ . '::plugin_dependency_notice' );
 			}


### PR DESCRIPTION
A workaround and viable fix for issue #142
added a filter to make up a date when the date return from the parent
function is 0 and the subscription was imported. This will then allow
switch subscriptions to work.

Note: this may cause issues with free trials where no payment has been
paid, testing is required to ensure it does not cause interference on
those imported subscriptions.