### PR TITLE
Allow updating status to pending-cancel and cancelled during import :see_no_evil:

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ If you need to import subscriptions using a payment gateway other than those abo
 
 > Note: Only subscriptions using PayPal Reference Transactions are supported. Subscriptions using PayPal Standard has a number of limitations that make it impossible to migrate them using the importer.
 
-### Importing Pending Cancelled Subscriptions
+### Importing Subscriptions with the Pending Cancellation Status
 
-There's a couple of things to note about which dates are used before you import a subscription with pending cancelled status.
+There's a couple of things to note about which dates are used before you import a subscription with _pending cancellation_ status.
 
-If the CSV row has a next payment date column and a value that is in the future, this date will be used as the end date (or end of prepaid term) for the pending cancelled subscription.
-If the row with pending cancellation status does not have a next payment date set, it will fall back to using the end date if that exists. If it doesn't exist, you will receive an error asking to set a valie end date when importing subscriptions with `pending-cancel` status.
+1. If the CSV row has a next payment date column and a value that is in the future, this date will be used as the end date (or end of prepaid term) for the pending cancelled subscription.
+1. If the row with pending cancellation status does _not_ have a next payment date set, it will fall back to using the end date if that exists. If it doesn't exist, you will receive an error asking to set a valie end date when importing subscriptions with `pending-cancel` status.
 
 To further explain, importing a subscription with pending cancellation status will require you to make sure an end date is set in the future and no next payment date is set, otherwise this next payment date will be used as the susbcriptions end date.
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,15 @@ If you need to import subscriptions using a payment gateway other than those abo
 
 > Note: Only subscriptions using PayPal Reference Transactions are supported. Subscriptions using PayPal Standard has a number of limitations that make it impossible to migrate them using the importer.
 
+### Importing Pending Cancelled Subscriptions
+
+There's a couple of things to note about which dates are used before you import a subscription with pending cancelled status.
+
+If the CSV row has a next payment date column and a value that is in the future, this date will be used as the end date (or end of prepaid term) for the pending cancelled subscription.
+If the row with pending cancellation status does not have a next payment date set, it will fall back to using the end date if that exists. If it doesn't exist, you will receive an error asking to set a valie end date when importing subscriptions with `pending-cancel` status.
+
+To further explain, importing a subscription with pending cancellation status will require you to make sure an end date is set in the future and no next payment date is set, otherwise this next payment date will be used as the susbcriptions end date.
+
 ### Importing Order Items
 
 In WooCommerce, orders can have a number of different line items, including:

--- a/assets/css/wcs-importer.css
+++ b/assets/css/wcs-importer.css
@@ -78,7 +78,7 @@
 	color: #fff;
 	font-weight: bold;
 	text-shadow:0 1px 0 rgba(0,0,0,0.3);
-	width: 66px;
+	width: 76px;
 }
 #wcsi-progress .column-status mark.active {
 	background-color: #339933;

--- a/assets/js/wcs-exporter-ajax.js
+++ b/assets/js/wcs-exporter-ajax.js
@@ -1,0 +1,25 @@
+jQuery(document).ready(function($){
+
+	var data = {
+		action:			'wcs_export_request',
+		file_name:		wcs_export_data.file_name,
+		customer:		end_pos,
+		payment_method:	start_pos,
+		payment_tokens:	start_pos,
+		statuses:		row_start,
+		csv_headers:	wcs_script_data.test_mode,
+		limit:			wcs_script_data
+	}
+
+	$.ajax({
+			url:	wcs_script_data.ajax_url,
+			type:	'POST',
+			data:	data,
+			timeout: 360000, // 6 minute timeout should be enough
+			success: function( results ) {
+
+			}
+
+	});
+
+});

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -281,7 +281,12 @@ class WCS_Importer {
 
 		// make the sure end of prepaid term exists for subscription that are about to be set to pending-cancellation
 		if ( in_array( $status, array( 'pending-cancel', 'wc-pending-cancel' ) ) && ( empty( $dates_to_update['next_payment_date'] ) || strtotime( $dates_to_update['next_payment_date'] ) < current_time( 'timestamp', true ) ) ) {
-			$result['error'][] = __( 'The next payment date must exist and be in the future in order to import a subscription with pending cancellation status.', 'wcs-import-export' );
+			if ( ! empty( $dates_to_update['end_date'] ) && strtotime( $dates_to_update['end_date'] ) > current_time( 'timestamp', true ) ) {
+				$dates_to_update['next_payment_date'] = $dates_to_update['end_date'];
+				unset( $dates_to_update['end_date'] );
+			} else {
+				$result['error'][] = __( 'Importing a pending cancelled subscription requires an end date in the future.', 'wcs-import-export' );
+			}
 		}
 
 		if ( empty( $result['error'] ) || self::$test_mode ) {

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -265,10 +265,6 @@ class WCS_Importer {
 
 			switch ( $date_type ) {
 				case 'end_date' :
-					if ( ! empty( $dates_to_update['last_payment_date'] ) && strtotime( $datetime ) <= strtotime( $dates_to_update['last_payment_date'] ) ) {
-						$result['error'][] = sprintf( __( 'The %s date must occur after the last payment date.', 'wcs-import-export' ), $date_type );
-					}
-
 					if ( ! empty( $dates_to_update['next_payment_date'] ) && strtotime( $datetime ) <= strtotime( $dates_to_update['next_payment_date'] ) ) {
 						$result['error'][] = sprintf( __( 'The %s date must occur after the next payment date.', 'wcs-import-export' ), $date_type );
 					}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -283,6 +283,11 @@ class WCS_Importer {
 			}
 		}
 
+		// make the sure end of prepaid term exists for subscription that are about to be set to pending-cancellation
+		if ( in_array( $status, array( 'pending-cancel', 'wc-pending-cancel' ) ) && ( empty( $dates_to_update['next_payment_date'] ) || strtotime( $dates_to_update['next_payment_date'] ) < current_time( 'timestamp', true ) ) ) {
+			$result['error'][] = __( 'The next payment date must exist and be in the future in order to import a subscription with pending cancellation status.', 'wcs-import-export' );
+		}
+
 		if ( empty( $result['error'] ) || self::$test_mode ) {
 			try {
 				if ( ! self::$test_mode ) {

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -333,7 +333,14 @@ class WCS_Importer {
 					}
 
 					$subscription->update_dates( $dates_to_update );
+
+					add_filter( 'woocommerce_can_subscription_be_updated_to_cancelled', '__return_true' );
+					add_filter( 'woocommerce_can_subscription_be_updated_to_pending-cancel', '__return_true' );
+
 					$subscription->update_status( $status );
+
+					remove_filter( 'woocommerce_can_subscription_be_updated_to_cancelled', '__return_true' );
+					remove_filter( 'woocommerce_can_subscription_be_updated_to_pending-cancel', '__return_true' );
 
 					if ( ! $set_manual && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) ) { // don't bother trying to set payment meta on a subscription that won't ever renew
 						$result['warning'] = array_merge( $result['warning'], self::set_payment_meta( $subscription, $data ) );

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -202,7 +202,6 @@ class WCS_Importer {
 					}
 					break;
 
-
 				case 'shipping_address_1':
 				case 'shipping_city':
 				case 'shipping_postcode':
@@ -279,7 +278,7 @@ class WCS_Importer {
 			}
 		}
 
-		// make the sure end of prepaid term exists for subscription that are about to be set to pending-cancellation
+		// make the sure end of prepaid term exists for subscription that are about to be set to pending-cancellation - continue to use the next payment date if that exists
 		if ( in_array( $status, array( 'pending-cancel', 'wc-pending-cancel' ) ) && ( empty( $dates_to_update['next_payment_date'] ) || strtotime( $dates_to_update['next_payment_date'] ) < current_time( 'timestamp', true ) ) ) {
 			if ( ! empty( $dates_to_update['end_date'] ) && strtotime( $dates_to_update['end_date'] ) > current_time( 'timestamp', true ) ) {
 				$dates_to_update['next_payment_date'] = $dates_to_update['end_date'];


### PR DESCRIPTION
This patch will force the `$subscription->can_be_updated_to()` to return true when the subscription is pending and we're trying to update the status the cancelled or pending cancelled.

This PR also throws in a fix to the CSS for pending cancelled status on the import page: https://cloudup.com/cqLZBsR_W10 (bad text alignment due to small fixed width on element)

I think in the future we'll calculate a next payment date (end of prepaid term) if it's not set in the CSV rather than just throwing an error. I think this is good for now as is though

Fixes #141 

cc @mheiduk 