### PR TITLE
Fixes FUE issue

### DIFF
--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -372,10 +372,7 @@ class WCS_Importer {
 					if ( is_numeric( $data[ self::$fields['order_items'] ] ) ) {
 						$product_id      = absint( $data[ self::$fields['order_items'] ] );
 						$result['items'] = self::add_product( $subscription, array( 'product_id' => $product_id ), $chosen_tax_rate_id );
-
-						if ( ! self::$test_mode && self::$add_memberships ) {
-							self::maybe_add_memberships( $user_id, $subscription->id, $product_id );
-						}
+						$order_items[]   = $product_id;
 					} else {
 						$order_items = explode( ';', $data[ self::$fields['order_items'] ] );
 

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -603,6 +603,12 @@ class WCS_Importer {
 				if ( $plan->has_product( $product_id ) ) {
 					$plan->grant_access_from_purchase( $user_id, $product_id, $subscription_id );
 				}
+
+				// if the product is a variation we want to also check if the parent variable product has any plans as well and add them
+				$product = wc_get_product( $product_id );
+				if ( $product && $product->is_type( 'variation' ) && ! empty( $product->parent->id ) && $plan->has_product( $product->parent->id ) ) {
+					$plan->grant_access_from_purchase( $user_id, $product->parent->id, $subscription_id );
+				}
 			}
 		}
 	}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -610,8 +610,9 @@ class WCS_Importer {
 				}
 
 				// if the product is a variation we want to also check if the parent variable product has any plans as well and add them
-				$product = wc_get_product( $product_id );
-				if ( $product && $product->is_type( 'variation' ) && ! empty( $product->parent->id ) && $plan->has_product( $product->parent->id ) ) {
+				$product   = wc_get_product( $product_id );
+				$parent_id = wcs_get_objects_property( $product, 'parent_id' );
+				if ( $product && $product->is_type( 'variation' ) && ! empty( $parent_id ) && $plan->has_product( $parent_id ) ) {
 					$plan->grant_access_from_purchase( $user_id, $product->parent->id, $subscription_id );
 				}
 			}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -247,7 +247,7 @@ class WCS_Importer {
 			$status              = 'pending';
 			$result['warning'][] = esc_html__( 'No subscription status was specified. The subscription will be created with the status "pending". ', 'wcs-import-export' );
 		} else {
-			$status = $data[ self::$fields['subscription_status'] ];
+			$status = ( 'wc-' === substr( $data[ self::$fields['subscription_status'] ], 0, 3 ) ) ? substr( $data[ self::$fields['subscription_status'] ], 3 ) : $data[ self::$fields['subscription_status'] ];
 		}
 
 		$dates_to_update = array( 'start' => ( ! empty( $data[ self::$fields['start_date'] ] ) ) ? gmdate( 'Y-m-d H:i:s', strtotime( $data[ self::$fields['start_date'] ] ) ) : gmdate( 'Y-m-d H:i:s', time() - 1 ) );
@@ -279,7 +279,7 @@ class WCS_Importer {
 		}
 
 		// make the sure end of prepaid term exists for subscription that are about to be set to pending-cancellation - continue to use the next payment date if that exists
-		if ( in_array( $status, array( 'pending-cancel', 'wc-pending-cancel' ) ) && ( empty( $dates_to_update['next_payment_date'] ) || strtotime( $dates_to_update['next_payment_date'] ) < current_time( 'timestamp', true ) ) ) {
+		if ( 'pending-cancel' == $status && ( empty( $dates_to_update['next_payment_date'] ) || strtotime( $dates_to_update['next_payment_date'] ) < current_time( 'timestamp', true ) ) ) {
 			if ( ! empty( $dates_to_update['end_date'] ) && strtotime( $dates_to_update['end_date'] ) > current_time( 'timestamp', true ) ) {
 				$dates_to_update['next_payment_date'] = $dates_to_update['end_date'];
 				unset( $dates_to_update['end_date'] );

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -145,7 +145,7 @@ class WCS_Importer {
 
 		self::$row  = $data;
 		$set_manual = $requires_manual_renewal = false;
-		$post_meta  = array();
+		$post_meta  = $order_items = array();
 		$result     = array(
 			'warning'    => array(),
 			'error'      => array(),
@@ -397,10 +397,7 @@ class WCS_Importer {
 								}
 
 								$result['items'] .= self::add_product( $subscription, $item_data, $chosen_tax_rate_id ) . '<br/>';
-
-								if ( ! self::$test_mode && self::$add_memberships ) {
-									self::maybe_add_memberships( $user_id, $subscription->id, $item_data['product_id'] );
-								}
+								$order_items[]    = $item_data['product_id'];
 							}
 						}
 					}

--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -374,10 +374,10 @@ class WCS_Importer {
 						$result['items'] = self::add_product( $subscription, array( 'product_id' => $product_id ), $chosen_tax_rate_id );
 						$order_items[]   = $product_id;
 					} else {
-						$order_items = explode( ';', $data[ self::$fields['order_items'] ] );
+						$order_items_row = explode( ';', $data[ self::$fields['order_items'] ] );
 
-						if ( ! empty( $order_items ) ) {
-							foreach ( $order_items as $order_item ) {
+						if ( ! empty( $order_items_row ) ) {
+							foreach ( $order_items_row as $order_item ) {
 								$item_data = array();
 
 								foreach ( explode( '|', $order_item ) as $item ) {


### PR DESCRIPTION
Fixes #140 (see issue for details)

To test,
1. Create a membership plan for a subscription product and also create a follow up email for that product (for example: https://cloudup.com/cQFGoVbtByH) and make sure it's active.
2. import the subscription as active and check the membership is active
3. check the FUE is scheduled (go to: `/wp-admin/admin.php?page=followup-emails-queue`

Tested on latest patch of each plugin.