### PR TITLE
Change user role

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -35,7 +35,7 @@ class WCS_Export_Admin {
 	 * @since 1.0
 	 */
 	public function add_sub_menu() {
-		add_submenu_page( 'woocommerce', __( 'Subscription Exporter', 'wcs-import-export' ),  __( 'Subscription Exporter', 'wcs-import-export' ), 'manage_options', 'export_subscriptions', array( &$this, 'export_page' ) );
+		add_submenu_page( 'woocommerce', __( 'Subscription Exporter', 'wcs-import-export' ),  __( 'Subscription Exporter', 'wcs-import-export' ), 'manage_woocommerce', 'export_subscriptions', array( &$this, 'export_page' ) );
 	}
 
 	/**

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -40,7 +40,7 @@ class WCS_Import_Admin {
 	 * @since 1.0
 	 */
 	public function add_sub_menu() {
-		add_submenu_page( 'woocommerce', __( 'Subscription Importer', 'wcs-import-export' ),  __( 'Subscription Importer', 'wcs-import-export' ), 'manage_options', 'import_subscription', array( &$this, 'admin_page' ) );
+		add_submenu_page( 'woocommerce', __( 'Subscription Importer', 'wcs-import-export' ),  __( 'Subscription Importer', 'wcs-import-export' ), 'manage_woocommerce', 'import_subscription', array( &$this, 'admin_page' ) );
 	}
 
 	/**


### PR DESCRIPTION
Change user role to `manage_woocommerce` which is given to Shop Manag…ers - instead of `manage_options` which requires Admin capability.

https://docs.woocommerce.com/document/roles-capabilities/
https://codex.wordpress.org/Roles_and_Capabilities#manage_options
https://github.com/woocommerce/woocommerce/blob/7b95988811a988053ae0c7e031ee75a3a838dff0/includes/class-wc-install.php#L657