### PR TITLE
Adaptations to WooCommerce 3. 

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -173,7 +173,7 @@ class WCS_Export_Admin {
 			'start_date'               => __( 'Start Date', 'wcs-import-export' ),
 			'trial_end_date'           => __( 'Trial End Date', 'wcs-import-export' ),
 			'next_payment_date'        => __( 'Next Payment Date', 'wcs-import-export' ),
-			'last_payment_date'        => __( 'Last Payment Date', 'wcs-import-export' ),
+			'last_payment_date'        => __( 'Last Order Date', 'wcs-import-export' ),
 			'end_date'                 => __( 'End Date', 'wcs-import-export' ),
 			'billing_period'           => __( 'Billing Period', 'wcs-import-export' ),
 			'billing_interval'         => __( 'Billing Interval', 'wcs-import-export' ),

--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -10,8 +10,6 @@ class WCS_Export_Admin {
 	public $action        = '';
 	public $error_message = '';
 
-	private $exporter = null;
-
 	/**
 	 * Initialise all admin hooks and filters for the subscriptions exporter
 	 *
@@ -97,7 +95,6 @@ class WCS_Export_Admin {
 	 * @since 1.0
 	 */
 	public function home_page() {
-		global $wpdb;
 
 		$statuses      = wcs_get_subscription_statuses();
 		$status_counts = array();
@@ -112,11 +109,11 @@ class WCS_Export_Admin {
 			<table class="widefat striped" id="wcsi-export-table">
 				<tbody>
 					<tr>
-						<td width="200"><label for="filename"><?php esc_html_e( 'Export File name', 'wcs-import-export' ); ?>:</label></th>
+						<td width="200"><label for="filename"><?php esc_html_e( 'Export File name', 'wcs-import-export' ); ?>:</label></td>
 						<td><input type="text" name="filename" placeholder="export filename" value="<?php echo ! empty( $_POST['filename'] ) ? esc_attr( $_POST['filename'] ) : 'subscriptions.csv'; ?>" required></td>
 					</tr>
 					<tr>
-						<td style="text-align:top"><?php esc_html_e( 'Subscription Statuses', 'wcs-import-export' ); ?>:</td>
+						<td style="vertical-align:top"><?php esc_html_e( 'Subscription Statuses', 'wcs-import-export' ); ?>:</td>
 						<td>
 							<?php foreach ( $statuses as $status => $status_display ) : ?>
 								<input type="checkbox" name="status[<?php echo esc_attr( $status ); ?>]" checked><?php echo esc_html( $status_display ); ?>  [<?php echo esc_html( ! empty( $status_counts[ $status ] ) ? $status_counts[ $status ] : 0 ); ?>]<br>
@@ -134,7 +131,7 @@ class WCS_Export_Admin {
 								<option value="any"><?php esc_html_e( 'Any Payment Method', 'wcs-import-export' ); ?></option>
 								<option value="none"><?php esc_html_e( 'None', 'wcs-import-export' ); ?></option>
 
-								<?php foreach ( WC()->payment_gateways->get_available_payment_gateways() as $gateway_id => $gateway ) : ?>
+								<?php foreach ( WC()->payment_gateways()->get_available_payment_gateways() as $gateway_id => $gateway ) : ?>
 									<option value="<?php echo esc_attr( $gateway_id ); ?>"><?php echo esc_html( $gateway->title ); ?></option>;
 								<?php endforeach; ?>
 							</select>

--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -87,7 +87,7 @@ class WCS_Exporter {
 					$value = version_compare( WC()->version, '3.0', '>=' ) ? 'wc-' . $subscription->get_status() : $subscription->post_status;
 					break;
 				case 'customer_id':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_customer_id() :$subscription->customer_user;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_customer_id() : $subscription->customer_user;
 					break;
 				case 'subscription_id':
 				case 'fee_total':
@@ -95,7 +95,7 @@ class WCS_Exporter {
 					$value = ${$header_key};
 					break;
 				case 'order_shipping':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_shipping_total() :$subscription->order_shipping;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_shipping_total() : $subscription->order_shipping;
 					if ( empty ( $value ) ) {
 						$value = 0;
 					}
@@ -107,25 +107,25 @@ class WCS_Exporter {
 					}
 					break;
 				case 'order_tax':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total_tax() :$subscription->order_tax;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total_tax() : $subscription->order_tax;
 					if ( empty ( $value ) ) {
 						$value = 0;
 					}
 					break;
 				case 'cart_discount':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total_discount() :$subscription->cart_discount;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total_discount() : $subscription->cart_discount;
 					if ( empty ( $value ) ) {
 						$value = 0;
 					}
 					break;
 				case 'cart_discount_tax':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_discount_tax() :$subscription->cart_discount_tax;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_discount_tax() : $subscription->cart_discount_tax;
 					if ( empty ( $value ) ) {
 						$value = 0;
 					}
 					break;
 				case 'order_total':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total() :$subscription->order_total;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_total() : $subscription->order_total;
 					if ( empty ( $value ) ) {
 						$value = 0;
 					}
@@ -146,9 +146,7 @@ class WCS_Exporter {
 					$value = version_compare( WC()->version, '3.0', '>=' ) ? $subscription->get_date( 'end' ) : $subscription->end_date;
 					break;
 				case 'requires_manual_renewal':
-					$value = version_compare( WC()->version, '3.0', '>=' ) ?
-						( $subscription->get_requires_manual_renewal() ? 'true' : 'false' ) :
-						$subscription->requires_manual_renewal;
+					$value = version_compare( WC()->version, '3.0', '>=' ) ? ( $subscription->get_requires_manual_renewal() ? 'true' : 'false' ) : $subscription->requires_manual_renewal;
 					break;
 				case 'billing_period':
 				case 'billing_interval':

--- a/includes/class-wcs-exporter.php
+++ b/includes/class-wcs-exporter.php
@@ -212,9 +212,6 @@ class WCS_Exporter {
 					$value      = '';
 					$line_items = array();
 
-					/**
-* @var  $item_id
-* @var WC_Order_Item_Product $item */
 					foreach ( $subscription->get_items() as $item_id => $item ) {
 
 						$meta_string = '';

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -58,8 +58,8 @@ class WCS_Import_Admin {
 
 				wp_enqueue_script( 'wcs-importer-admin', WCS_Importer_Exporter::plugin_url() . 'assets/js/wcs-importer.js' );
 
-				$file_id = absint( $_GET['file_id'] );
-				$file    = get_attached_file( $_GET['file_id'] );
+                $file_id = absint( $_GET['file_id'] );
+				$file    = get_attached_file( $file_id );
 				$enc     = mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true );
 
 				if ( $enc ) {
@@ -283,6 +283,8 @@ class WCS_Import_Admin {
 	 */
 	private function mapping_page() {
 
+		$row = array();
+
 		$file_id = absint( $_GET['file_id'] );
 		$file    = get_attached_file( $file_id );
 
@@ -296,8 +298,6 @@ class WCS_Import_Admin {
 			@ini_set( 'auto_detect_line_endings', true );
 
 			if ( ( $handle = fopen( $file, 'r' ) ) !== false ) {
-
-				$row            = array();
 				$column_headers = fgetcsv( $handle, 0 );
 
 				while ( ( $postmeta = fgetcsv( $handle, 0 ) ) !== false ) {

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -58,7 +58,7 @@ class WCS_Import_Admin {
 
 				wp_enqueue_script( 'wcs-importer-admin', WCS_Importer_Exporter::plugin_url() . 'assets/js/wcs-importer.js' );
 
-                $file_id = absint( $_GET['file_id'] );
+				$file_id = absint( $_GET['file_id'] );
 				$file    = get_attached_file( $file_id );
 				$enc     = mb_detect_encoding( $file, 'UTF-8, ISO-8859-1', true );
 


### PR DESCRIPTION
Addressing #165, this PR includes adaptations so the plugin runs against WooCommerce 3.0.
I've tested the export part successfully. 

In my client's site we don't need the import part, so this part hasn't been tested yet. Nevertheless the main issues (such as accessing to private properties) have also been corrected.