### PR TITLE
Handle HTTP errors during import

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,28 @@ To view the shutdown logs:
 01-12-2016 @ 05:52:16 - PHP Fatal error Call to undefined method WCS_Importer::add_coupons() in /Users/Matt/Dropbox/Sites/subs2.0/wp-content/plugins/woocommerce-subscriptions-importer-exporter/includes/class-wcs-import-parser.php on line 425.
 ```
 
+### Import HTTP Error Handling
+
+While the _Import Error Logs_ handle PHP errors that can be caught and logged, the Importer will also attempt to handle HTTP errors from Ajax.
+
+To this, it will:
+
+1. catch a HTTP error code returned by the request and
+    1. display the HTTP error in the _Importing Results_ table
+    1. output the full `xmlhttprequest` object to the console
+1. wait for 20 seconds
+1. resume the import by attempting the next set of rows
+
+Importantly, **the set of rows with a failure will not be reattempted as there is no way to know which subscriptions were imported successfully**. The subscriptions in the rows with HTTP errors need to be manually checked.
+
+To aid in checking these rows, the Importer will provide:
+
+1. the rows affected during the import when the HTTP error code is detected
+1. a list of all rows affected during the entire import once the import process completes
+
+![](https://cl.ly/2c353z3d0k1i/Screen%20Shot%202018-02-23%20at%2010.23.17%20am.png)
+**Screenshot of CSV Import affected by various HTTP errors**
+
 ## CSV Formatting Guide
 By far the most difficult aspect of migrating your subscriptions using the CSV Importer is formatting a valid CSV with all required data.
 

--- a/assets/css/wcs-importer.css
+++ b/assets/css/wcs-importer.css
@@ -52,6 +52,12 @@
 	padding-left: 1em;
 }
 
+#wcsi-progress .http-error-import-retry td.row,
+#wcsi-progress .http-error-import td.row {
+	text-align: left;
+	padding-left: 6em;
+}
+
 .wcsier-download {
 	display: inline-block;
 	margin-right: 16px;

--- a/templates/import-results.php
+++ b/templates/import-results.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <h3><?php esc_html_e( 'Importing Results', 'wcs-import-export' ); ?></h3>
 
-<p id="wcsi-timeout" style="display: none;">
-	<?php echo wp_kses( sprintf( __( 'Error: The importing process has timed out. Please check the CSV is correct and do a test run before importing by enabling the checkbox on the Importer Home screen. %1$s Start Over. %2$s', 'wcs-import-export' ), '<a href="' . $this->admin_url . '">', '</a>' ), array( 'a' => array( 'href' => true ) ) ); ?>
+<p id="wcsi-error" style="display: none;">
+	<?php echo wp_kses( sprintf( __( 'Error: The importing process could not be completed due to HTTP errors. %1$s Start Over. %2$s', 'wcs-import-export' ), '<a href="' . $this->admin_url . '">', '</a>' ), array( 'a' => array( 'href' => true ) ) ); ?>
 </p>
 <p id="wcsi-time-completion">
 	<?php echo wp_kses( sprintf( __( 'Total Estimated Import Time Between: %1$s 0%2$s minutes. ( %3$s0%4$s Completed! )', 'wcs-import-export' ), '<span id="wcsi-estimated-time">', '</span>', '<span id="wcsi-completed-percent">', '</span>' ), array( 'span' => array( 'id' => true ) ) ); ?>


### PR DESCRIPTION
Display the HTTP error code and message in the import admin table to make it easier to track and diagnose HTTP errors, namely timeout errors, but also other miscellaneous HTTP errors that may occur.

Also retry import request for 5 minutes to allow it to remain running for long periods of time to process large batches rather than stopping the rest of the import just for one HTTP error. However, do not retry the same batch, only retry *the next* batch, because we have no way of knowing how many rows successfully completed or failed from the previous batch.

Example screen showing two HTTP errors at the beginning on the import:

![](https://cl.ly/3Y3L3K0n432E/Screen%20Shot%202018-02-22%20at%2012.07.00%20pm.png)

Example screenshot showing HTTP errors midway through an import:

![](https://cl.ly/2X0A2c1I1l3a/Screen%20Shot%202018-02-22%20at%2012.04.40%20pm.png)

