### PR TITLE
Reload subscription after any possible updates of meta values and save

### DIFF
--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -592,7 +592,10 @@ class WCS_Importer {
 				}
 
 				if ( $meta_set ) {
+					// Reload the subscription to update the meta values.
+					$subscription  = wcs_get_subscription( $subscription->get_id() );
 					$subscription->set_payment_method( $payment_gateway, $payment_method_data );
+					$subscription->save();
 				} else {
 					$warnings[] = sprintf( esc_html__( 'No payment meta was set for your %1$s subscription (%2$s). The next renewal is going to fail if you leave this.', 'wcs-import-export' ), $payment_method, $subscription_id );
 				}


### PR DESCRIPTION
Fixes: #197 

The cause of this issue is the same as the cause of prospress/woocommerce-subscriptions#2990 and so I fixed it by reloading the subscription before `set_payment_method()` is called and saving the subscription after.