### PR TITLE
Moved the update_dates() call to update them after updating the subscription status

### DIFF
--- a/includes/class-wcs-importer.php
+++ b/includes/class-wcs-importer.php
@@ -371,8 +371,6 @@ class WCS_Importer {
 					// Now that we've set all the meta data, reinit the object so the data is set
 					$subscription = wcs_get_subscription( $subscription_id );
 
-					$subscription->update_dates( $dates_to_update );
-
 					if ( ! $set_manual && ! in_array( $status, wcs_get_subscription_ended_statuses() ) ) { // don't bother trying to set payment meta on a subscription that won't ever renew
 						$result['warning'] = array_merge( $result['warning'], self::set_payment_meta( $subscription, $data ) );
 					}
@@ -460,6 +458,8 @@ class WCS_Importer {
 					add_filter( 'woocommerce_can_subscription_be_updated_to_pending-cancel', '__return_true' );
 
 					$subscription->update_status( $status );
+
+					$subscription->update_dates( $dates_to_update );
 
 					remove_filter( 'woocommerce_can_subscription_be_updated_to_cancelled', '__return_true' );
 					remove_filter( 'woocommerce_can_subscription_be_updated_to_pending-cancel', '__return_true' );


### PR DESCRIPTION
### Description
When you're importing expired subscriptions with their "End date", this date is automatically replaced by the current date (the importation time).

### Steps to replicate
1. Make sure that you have an expired subscription on your site (if not, create one and change its "end date" [`_schedule_end`] from the database to have an old date)
2. Export this subscription
3. Delete the subscription
4. Import it and check if its 'End date' has the same date as the original subscription

### Expected results
After importing the subscription, its "End date" should be the same date that was specified in the CSV.

### Result
The "End date" of the imported subscription is replaced with the current date.

### Origin of the issue
I see that the plugin updates the dates of the subscription *before* updating its status. In this case, when the status of a subscription is updated to "Expired", it overwrites the "End date" with the current date.

### Note
I suggest to move the update_dates() call after the update_status() to make sure that the imported dates are preserved. I'm not sure though if removing this call from the previous location affects any specific cases (at first glance, this change doesn't seem problematic, as both methods will be called anyway, and the doesn't seem to be any specific reason to update the subscription dates before).

Fixes #201