### PR TITLE
Switches from prospress/ to woocommerce/ in links

### DIFF
--- a/wcs-importer-exporter.php
+++ b/wcs-importer-exporter.php
@@ -96,8 +96,8 @@ class WCS_Importer_Exporter {
 
 		$plugin_links = array(
 			'<a href="' . esc_url( admin_url( 'admin.php?page=import_subscription' ) ) . '">' . esc_html__( 'Import', 'wcs-import-export' ) . '</a>',
-			'<a href="https://github.com/Prospress/woocommerce-subscriptions-importer-exporter/blob/master/README.md">' . esc_html__( 'Docs', 'wcs-import-export' ) . '</a>',
-			'<a href="https://github.com/Prospress/woocommerce-subscriptions-importer-exporter/issues/new">' . esc_html__( 'Support', 'wcs-import-export' ) . '</a>',
+			'<a href="https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter/blob/master/README.md">' . esc_html__( 'Docs', 'wcs-import-export' ) . '</a>',
+			'<a href="https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter/issues/new">' . esc_html__( 'Support', 'wcs-import-export' ) . '</a>',
 		);
 
 		return array_merge( $plugin_links, $links );


### PR DESCRIPTION
Replaces /prospress/ with /woocommerce/ in Docs & Settings links on the Plugins administration screen, as it was redirecting to /woocommerce/

P.S. Request to add label _hacktoberfest-accepted_ to the PR on acceptance. Thanks!