### PR TITLE
Sort CSV cron exports by date (desc)

### DIFF
--- a/includes/class-wcs-export-admin.php
+++ b/includes/class-wcs-export-admin.php
@@ -293,15 +293,26 @@ class WCS_Export_Admin {
 					$status = 'processing';
 				}
 
+				$ctime = absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) );
+
 				$file_data = array(
 					'name'   => $file,
 					'url'    => $files_url . $file,
 					'status' => $status,
-					'date'   => date( 'd/m/Y G:i:s', absint( filectime( trailingslashit( WCS_Exporter_Cron::$cron_dir ) . $file ) ) ),
+					'ctime'  => $ctime,
+					'date'   => date( 'd/m/Y G:i:s', $ctime ),
 				);
 
 				$files_data[] = $file_data;
 			}
+
+			// Sort files by date (desc).
+			usort(
+				$files_data,
+				function( $file1, $file2 ) {
+					return $file2['ctime'] - $file1['ctime'];
+				}
+			);
 		}
 		?>
 		<table class="widefat widefat_crons striped" id="wcsi-cron-exports-table" style="display:none;">

--- a/includes/class-wcs-import-admin.php
+++ b/includes/class-wcs-import-admin.php
@@ -518,7 +518,7 @@ class WCS_Import_Admin {
 		}
 
 		foreach ( $mapping_rules as $key => $value ) {
-			if ( ! empty( $value ) && is_array( $mapped_fields[ $value ] ) ) {
+			if ( ! empty( $value ) && isset( $mapped_fields[ $value ] ) && is_array( $mapped_fields[ $value ] ) ) {
 				array_push( $mapped_fields[ $value ], $key );
 			}
 		}


### PR DESCRIPTION
The table in WC > Subscription Exporter > Cron exports lists exports as provided by the filesystem, but this can be a bit confusing, as recent files might appear in the middle of the table between older files.
This PR makes sure all exports are sorted by the time the file was last modified. Assuming these files are not manipulated in the server (after the export) this actually means newer files now appear on top.

### Testing instructions

1. Go to WC > Subscriptions Exporte and perform a few exports.
2. Make sure they are listed in WC > Subscription Exporter > Cron exports with newer files on top and older files at the bottom.